### PR TITLE
Issue #58: Added a best match in event of an error

### DIFF
--- a/services/bot/package.json
+++ b/services/bot/package.json
@@ -73,6 +73,7 @@
     "migrate-mongo": "^8.2.2",
     "moment": "^2.29.1",
     "mongoose": "^5.12.10",
+    "string-similarity": "^4.0.4",
     "webex": "1.120.0",
     "winston": "^3.3.3"
   }

--- a/services/bot/src/commands/queue/get.ts
+++ b/services/bot/src/commands/queue/get.ts
@@ -23,13 +23,16 @@ export class Get extends CommandBase implements ICommand {
      * @returns The response string.
      */
     public async relax (initiative: IInitiative): Promise<string> {
-        // TODO: list "how long" as part of listing the queue
         const project = await CommandBase.getProject(initiative);
         if (typeof project === 'string') return String(project);
 
         // Get queue
         const queueName = initiative.data.queue?.toUpperCase() || project.currentQueue;
-        const queue = project.queues.filter(i => i.name === queueName)[0];
-        return [CommandBase.queueToString(queue), await CommandBase.getHowLong(queue, initiative.user)].join('\n\n');
+        const queue = project.queues.filter(i => i.name === queueName);
+        if (queue.length > 0) {
+            return [CommandBase.queueToString(queue[0]), await CommandBase.getHowLong(queue[0], initiative.user)].join('\n\n');
+        } else {
+            return `Queue "${queueName}" does not exist. Use 'list queues' to show what queues are available.`;
+        }
     }
 }

--- a/services/bot/src/handler.ts
+++ b/services/bot/src/handler.ts
@@ -56,6 +56,9 @@ export class Handler {
                     result = await initiative.action.relax(initiative);
                 } else {
                     result = 'Command not recognized. Try using "help" for more information.';
+                    if (Object.keys(initiative.similarity.action).length > 0) {
+                        result += ` Closest command regex match is: ${initiative.similarity.action}`;
+                    }
                 }
                 if (result) {
                     await this.handleDebug(initiative, request, result);

--- a/services/bot/src/logger.ts
+++ b/services/bot/src/logger.ts
@@ -5,7 +5,7 @@
 import { createLogger, format, transports } from 'winston';
 
 export const LOGGER = createLogger({
-    level: process.env.NODE_ENV === 'production' ? 'info' : process.env.QUTEX_TESTING && process.argv.indexOf('--silent') <= 0 ? 'warn' : 'verbose',
+    level: process.env.NODE_ENV === 'production' ? 'info' : process.env.QUTEX_TESTING && process.argv.indexOf('--silent') <= 0 ? 'warn' : 'debug',
     format: format.combine(
         format.colorize({ all: true }),
         format.timestamp(),

--- a/services/bot/src/logger.ts
+++ b/services/bot/src/logger.ts
@@ -5,7 +5,7 @@
 import { createLogger, format, transports } from 'winston';
 
 export const LOGGER = createLogger({
-    level: process.env.NODE_ENV === 'production' ? 'info' : process.env.QUTEX_TESTING && process.argv.indexOf('--silent') <= 0 ? 'warn' : 'debug',
+    level: process.env.NODE_ENV === 'production' ? 'info' : process.env.QUTEX_TESTING && process.argv.indexOf('--silent') <= 0 ? 'warn' : 'verbose',
     format: format.combine(
         format.colorize({ all: true }),
         format.timestamp(),

--- a/services/bot/src/parser.ts
+++ b/services/bot/src/parser.ts
@@ -75,10 +75,16 @@ export class Parser {
         }
 
         let commandData: any = {}; //eslint-disable-line @typescript-eslint/no-explicit-any
+        const bestMatch = { 'similarity': 0.3, action: {} };
 
         // Determine the appropriate action
         for (const command of Commands) {
-            const data = await command.check(rawCommand);
+            const checkData = await command.check(rawCommand);
+            const data = checkData[0];
+            if (checkData[1] > bestMatch.similarity) {
+                bestMatch.similarity = checkData[1];
+                bestMatch.action = (command as any).commandWithArgs;
+            }
             // TODO: data type should be easier to work with
             if (data instanceof Object && data.action) delete data.action;
             if (data) {
@@ -96,6 +102,7 @@ export class Parser {
             user: user,
             data: commandData.data,
             action: commandData.action,
+            similarity: commandData ? bestMatch : {},
             mentions: mentions.filter(i => i !== me.id)
         };
 

--- a/services/bot/tests/commands/queue/get.test.ts
+++ b/services/bot/tests/commands/queue/get.test.ts
@@ -39,6 +39,15 @@ describe('Getting a queue works appropriately', () => {
             `Queue "DEFAULT":\n\n1. ${STANDARD_USER.displayName} (May 6, 2021 01:43:08 AM EST)\n\nYou are at the head of the queue so you have no estimated wait time!`
         );
     });
+    test('Errors when queue doesnt exist', async () => {
+        const project = await CREATE_PROJECT();
+        expect(project.admins).toEqual(expect.arrayContaining([expect.objectContaining(TEST_PROJECT.admins[0])]));
+        expect(await PERSON_MODEL.find({ id: TEST_INITIATIVE.user.id }).exec()).toHaveLength(0);
+
+        expect(await new Get().relax({ ...TEST_INITIATIVE, data: { queue: 'foobar' } })).toEqual(
+            'Queue "FOOBAR" does not exist. Use \'list queues\' to show what queues are available.'
+        );
+    });
     test('Gets non-default queue successfully when project exists', async () => {
         let project = await CREATE_PROJECT();
         await CREATE_QUEUE(project, 'FOO');

--- a/services/bot/tests/handler.test.ts
+++ b/services/bot/tests/handler.test.ts
@@ -99,7 +99,7 @@ describe('Handler is working', () => {
         expect(BOT.messages.get).toHaveBeenCalledWith(MOCK_REQUEST.body.data.id);
         expect(BOT.messages.create).toHaveBeenCalledWith({
             toPersonId: 'mockPersonId',
-            markdown: 'Command not recognized. Try using "help" for more information.'
+            markdown: 'Command not recognized. Try using "help" for more information. Closest command regex match is: (get|show) status'
         });
     });
     test('handler appropriately checks message contents and sends response for get status using person email', async () => {
@@ -215,6 +215,10 @@ describe('Handler is working', () => {
                         'COMMAND_BASE': 'project',
                         'ARGS': '{name:[\\w\\s]+}',
                         'DESCRIPTION': 'Creates a target project'
+                    },
+                    'similarity': {
+                        'similarity': 0.5454545454545454,
+                        'action': 'create project {name:[\\w\\s]+}'
                     },
                     'mentions': []
                 },

--- a/services/bot/tests/util.ts
+++ b/services/bot/tests/util.ts
@@ -34,7 +34,8 @@ export const TEST_INITIATIVE: IInitiative = {
     action: null,
     debug: false,
     user: STANDARD_USER,
-    mentions: []
+    mentions: [],
+    similarity: { similarity: 0.3, action: {} }
 };
 export const TEST_QUEUE_MEMBER: IQueueMember = { person: TEST_OTHER_USER, enqueuedAt: new Date('2020-01-01'), atHeadTime: null };
 /**

--- a/services/bot/types/command.d.ts
+++ b/services/bot/types/command.d.ts
@@ -34,7 +34,7 @@ interface ICommand {
      *
      * @access public
      */
-    check: (command: string) => Promise<Record<string, string> | boolean | string | null | undefined>;
+    check: (command: string) => Promise<[Record<string, string> | boolean | string | null | undefined, number]>;
 
     /**
      * This function should perform the action of the command.

--- a/services/bot/types/initiative.d.ts
+++ b/services/bot/types/initiative.d.ts
@@ -92,4 +92,9 @@ interface IInitiative {
      */
     time?: Date;
 
+    /**
+     * This object shows the similarity for the closest matched command if the command is unrecognized.
+     */
+    similarity: Record<string, Command | number>;
+
 }

--- a/services/bot/types/string-similarity.d.ts
+++ b/services/bot/types/string-similarity.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @file Necessary for the string-similarity types to be recognized by typescript.
+ * @author Ava Thorn
+ */
+
+declare module 'string-similarity';

--- a/services/bot/yarn.lock
+++ b/services/bot/yarn.lock
@@ -7243,6 +7243,11 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-similarity@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
+
 string-width@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"


### PR DESCRIPTION
Resolves #58 

Added ability to do a naive similarity check to find the closest match (Assuming at least a 30% match) to display to the user in case of an error.